### PR TITLE
Sort documents in integer oder instead of lexicographic

### DIFF
--- a/tools/create_viewer_cb.config
+++ b/tools/create_viewer_cb.config
@@ -58,3 +58,7 @@ multiple_types = false
 # A document has a label taht we can't parse
 # As far as I know this should not happen.
 bad_label = false
+
+# A directory has a name in a form which is unexpected for a document
+# As far as I know this should not happen.
+unexpected_directory = false


### PR DESCRIPTION
Fixes the following issue: for long documents, pages would be shown in
order 1 10 11 12 13 2 3 4 5 6 7 8 9 for example.

I took the liberty to add typing annotations. They can be checked by LSP servers and the command `mypy tools/create_viewer_cb.py`. I would even be possible to check this in CI.