### PR TITLE
Changes to make integration with Paperwork possible

### DIFF
--- a/app/schemas/net.phbwt.paperwork.data.AppDatabase/2.json
+++ b/app/schemas/net.phbwt.paperwork.data.AppDatabase/2.json
@@ -1,0 +1,317 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 1,
+    "identityHash": "b98ba9656efaa89f4eafd08b96a3d81a",
+    "entities": [
+      {
+        "tableName": "Document",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`documentId` INTEGER NOT NULL, `name` TEXT NOT NULL, `title` TEXT, `thumb` TEXT, `pageCount` INTEGER NOT NULL, `date` INTEGER NOT NULL, `mtime` INTEGER NOT NULL, `size` INTEGER NOT NULL, PRIMARY KEY(`documentId`))",
+        "fields": [
+          {
+            "fieldPath": "documentId",
+            "columnName": "documentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "thumb",
+            "columnName": "thumb",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageCount",
+            "columnName": "pageCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mtime",
+            "columnName": "mtime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "size",
+            "columnName": "size",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "documentId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "Document_date",
+            "unique": false,
+            "columnNames": [
+              "date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `Document_date` ON `${TABLE_NAME}` (`date`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "Part",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`partId` INTEGER NOT NULL, `documentId` INTEGER NOT NULL, `name` TEXT NOT NULL, `downloadStatus` INTEGER NOT NULL, `downloadError` TEXT, PRIMARY KEY(`partId`), FOREIGN KEY(`documentId`) REFERENCES `Document`(`documentId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "partId",
+            "columnName": "partId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "documentId",
+            "columnName": "documentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadStatus",
+            "columnName": "downloadStatus",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadError",
+            "columnName": "downloadError",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "partId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "Part_documentId",
+            "unique": false,
+            "columnNames": [
+              "documentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `Part_documentId` ON `${TABLE_NAME}` (`documentId`)"
+          },
+          {
+            "name": "Part_downloadStatus",
+            "unique": false,
+            "columnNames": [
+              "downloadStatus"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `Part_downloadStatus` ON `${TABLE_NAME}` (`downloadStatus`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "Document",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "documentId"
+            ],
+            "referencedColumns": [
+              "documentId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "Label",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`labelId` INTEGER NOT NULL, `documentId` INTEGER NOT NULL, `name` TEXT NOT NULL, `color` TEXT, PRIMARY KEY(`labelId`), FOREIGN KEY(`documentId`) REFERENCES `Document`(`documentId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "labelId",
+            "columnName": "labelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "documentId",
+            "columnName": "documentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "labelId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "Label_documentId",
+            "unique": false,
+            "columnNames": [
+              "documentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `Label_documentId` ON `${TABLE_NAME}` (`documentId`)"
+          },
+          {
+            "name": "Label_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `Label_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "Document",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "documentId"
+            ],
+            "referencedColumns": [
+              "documentId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "DocumentText",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`documentId` INTEGER NOT NULL, `main` TEXT NOT NULL, `additional` TEXT, PRIMARY KEY(`documentId`), FOREIGN KEY(`documentId`) REFERENCES `Document`(`documentId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "documentId",
+            "columnName": "documentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "main",
+            "columnName": "main",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "additional",
+            "columnName": "additional",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "documentId"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "Document",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "documentId"
+            ],
+            "referencedColumns": [
+              "documentId"
+            ]
+          }
+        ]
+      },
+      {
+        "ftsVersion": "FTS4",
+        "ftsOptions": {
+          "tokenizer": "unicode61",
+          "tokenizerArgs": [],
+          "contentTable": "DocumentText",
+          "languageIdColumnName": "",
+          "matchInfo": "FTS4",
+          "notIndexedColumns": [],
+          "prefixSizes": [],
+          "preferredOrder": "ASC"
+        },
+        "contentSyncTriggers": [
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_DocumentFts_BEFORE_UPDATE BEFORE UPDATE ON `DocumentText` BEGIN DELETE FROM `DocumentFts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_DocumentFts_BEFORE_DELETE BEFORE DELETE ON `DocumentText` BEGIN DELETE FROM `DocumentFts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_DocumentFts_AFTER_UPDATE AFTER UPDATE ON `DocumentText` BEGIN INSERT INTO `DocumentFts`(`docid`, `main`, `additional`) VALUES (NEW.`rowid`, NEW.`main`, NEW.`additional`); END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_DocumentFts_AFTER_INSERT AFTER INSERT ON `DocumentText` BEGIN INSERT INTO `DocumentFts`(`docid`, `main`, `additional`) VALUES (NEW.`rowid`, NEW.`main`, NEW.`additional`); END"
+        ],
+        "tableName": "DocumentFts",
+        "createSql": "CREATE VIRTUAL TABLE IF NOT EXISTS `${TABLE_NAME}` USING FTS4(`main` TEXT NOT NULL, `additional` TEXT, tokenize=unicode61, content=`DocumentText`)",
+        "fields": [
+          {
+            "fieldPath": "main",
+            "columnName": "main",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "additional",
+            "columnName": "additional",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowid"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'b98ba9656efaa89f4eafd08b96a3d81a')"
+    ]
+  }
+}

--- a/app/src/main/java/net/phbwt/paperwork/data/AppDatabase.kt
+++ b/app/src/main/java/net/phbwt/paperwork/data/AppDatabase.kt
@@ -8,7 +8,7 @@ import net.phbwt.paperwork.data.dao.LabelDao
 import net.phbwt.paperwork.data.entity.*
 
 @Database(
-    version = 1,
+    version = 2,
     entities = [
         Document::class,
         Part::class,

--- a/app/src/main/java/net/phbwt/paperwork/data/Repository.kt
+++ b/app/src/main/java/net/phbwt/paperwork/data/Repository.kt
@@ -190,7 +190,7 @@ fun OkHttpClient.withHttpCache(
     Log.d(TAG, "Adding cache to OkHttpClient")
     cacheDir.mkdirs()
     return newBuilder()
-        .cache(Cache(cacheDir, 32 * 1024 * 1024L))
+        .cache(Cache(cacheDir, 256 * 1024 * 1024L))
         .build()
 }
 

--- a/app/src/main/java/net/phbwt/paperwork/data/background/DownloadWorker.kt
+++ b/app/src/main/java/net/phbwt/paperwork/data/background/DownloadWorker.kt
@@ -241,13 +241,6 @@ class DownloadWorker @AssistedInject constructor(
         Log.d(TAG, "Downloading ${dnl.partPath()}")
 
         var url = "$baseUrl/${dnl.partPath()}"
-        if (BuildConfig.DEBUG) {
-            // error injection
-            if (Random.Default.nextInt() % 3 == 0) {
-                Log.e(TAG, "Injecting an error")
-                url += "error"
-            }
-        }
 
         val request = Request.Builder()
             .url(url)

--- a/app/src/main/java/net/phbwt/paperwork/data/dao/DocumentQueryBuilder.kt
+++ b/app/src/main/java/net/phbwt/paperwork/data/dao/DocumentQueryBuilder.kt
@@ -71,7 +71,7 @@ select ${selects.joinToString(", ")}
 from Document d
 ${joins.joinToString("\n")}
 ${if (wheres.isNotEmpty()) wheres.joinToString(" and ", " where ") else ""}
-order by d.documentId
+order by d.date DESC
 limit 150
 """
 

--- a/app/src/main/java/net/phbwt/paperwork/data/entity/Document.kt
+++ b/app/src/main/java/net/phbwt/paperwork/data/entity/Document.kt
@@ -2,9 +2,15 @@ package net.phbwt.paperwork.data.entity
 
 import androidx.compose.runtime.Immutable
 import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
 import androidx.room.PrimaryKey
 
-@Entity
+@Entity(
+    indices = [
+        Index("date", name = "Document_date"),
+    ]
+)
 @Immutable
 data class Document(
     @PrimaryKey

--- a/app/src/main/java/net/phbwt/paperwork/data/entity/DocumentText.kt
+++ b/app/src/main/java/net/phbwt/paperwork/data/entity/DocumentText.kt
@@ -9,6 +9,7 @@ import androidx.room.*
             entity = Document::class,
             parentColumns = arrayOf("documentId"),
             childColumns = arrayOf("documentId"),
+            onDelete = ForeignKey.CASCADE,
         ),
     ],
 )

--- a/app/src/main/java/net/phbwt/paperwork/data/entity/Label.kt
+++ b/app/src/main/java/net/phbwt/paperwork/data/entity/Label.kt
@@ -10,6 +10,7 @@ import androidx.room.*
             entity = Document::class,
             parentColumns = arrayOf("documentId"),
             childColumns = arrayOf("documentId"),
+            onDelete = ForeignKey.CASCADE,
         ),
     ],
     indices = [

--- a/app/src/main/java/net/phbwt/paperwork/data/entity/Part.kt
+++ b/app/src/main/java/net/phbwt/paperwork/data/entity/Part.kt
@@ -9,6 +9,7 @@ import androidx.room.*
             entity = Document::class,
             parentColumns = arrayOf("documentId"),
             childColumns = arrayOf("documentId"),
+            onDelete = ForeignKey.CASCADE,
         ),
     ],
     indices = [

--- a/tools/create_viewer_cb.py
+++ b/tools/create_viewer_cb.py
@@ -220,6 +220,7 @@ CREATE TABLE Document (
   mtime INTEGER NOT NULL,
   size INTEGER NOT NULL
 );
+CREATE INDEX IF NOT EXISTS Document_date on Document(date);
 
 CREATE TABLE Part (
   partId INTEGER NOT NULL PRIMARY KEY,

--- a/tools/create_viewer_cb.py
+++ b/tools/create_viewer_cb.py
@@ -227,7 +227,7 @@ CREATE TABLE Part (
   name TEXT NOT NULL,
   downloadStatus INTEGER NOT NULL DEFAULT 100,
   downloadError TEXT NULL,
-  CONSTRAINT fkDocument FOREIGN KEY (documentId) REFERENCES Document(documentId)
+  CONSTRAINT fkDocument FOREIGN KEY (documentId) REFERENCES Document(documentId) ON DELETE CASCADE
 );
 CREATE INDEX Part_documentId on Part(documentId);
 CREATE INDEX Part_downloadStatus on Part(downloadStatus);
@@ -237,7 +237,7 @@ CREATE TABLE Label (
   documentId INTEGER NOT NULL,
   name TEXT NOT NULL,
   color TEXT,
-  CONSTRAINT fkDocument FOREIGN KEY (documentId) REFERENCES Document(documentId)
+  CONSTRAINT fkDocument FOREIGN KEY (documentId) REFERENCES Document(documentId) ON DELETE CASCADE
 );
 CREATE INDEX Label_documentId on Label(documentId);
 CREATE INDEX Label_name on Label(name);
@@ -246,7 +246,7 @@ CREATE TABLE DocumentText (
   documentId INTEGER NOT NULL PRIMARY KEY,
   main TEXT NOT NULL,
   additional TEXT NULL,
-  CONSTRAINT fkDocument FOREIGN KEY (documentId) REFERENCES Document(documentId)
+  CONSTRAINT fkDocument FOREIGN KEY (documentId) REFERENCES Document(documentId) ON DELETE CASCADE
 );
 
 CREATE VIRTUAL TABLE DocumentFts USING FTS4(


### PR DESCRIPTION
If you want, you can give it a try:

- ~~Changes in Paperwork are in the branch [wip-openpaperview](https://gitlab.gnome.org/World/OpenPaperwork/paperwork/-/tree/wip-openpaperview)~~ (Update: I've pushed my changes in Paperwork on the branch `master`. There is no branch `wip-openpaperview` anymore)
- Right now, only the CLI allows exposing the HTTPS server: `paperwork-cli https serve` will generate the certificates and start the HTTPS server. I'm working on the GUI.

I still have problems with Cache-Control. I'm unclear how it's supposed to work with your app:
Your app only specifies "Cache-Control: max-age=0" in its HTTP headers. I would have assumed it would send a header `If-Modified-Since` too, but it doesn't. So the server has no way to know if your app already got the latest version of the DB. I have a feeling you only get HTTP 304 because your app reuse the same HTTPS connection.

Also, I've spent the last 3 hours wondering why I got randomly some weird queries with URLs ending in "error". So I've allowed myself to remove your test code ...


